### PR TITLE
Support Elixir 1.18 in GitHub CI

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,45 +11,48 @@ jobs:
       matrix:
         include:
           - pair:
-              otp: 27.x
-              elixir: 1.17.x
-              lint: lint
+              otp: "27"
+              elixir: "1.18"
+            lint: lint
+          - pair:
+              otp: "27"
+              elixir: "1.17"
 
           - pair:
-              otp: 26.x
-              elixir: 1.17.x
+              otp: "26"
+              elixir: "1.17"
           - pair:
-              otp: 26.x
-              elixir: 1.16.x
+              otp: "26"
+              elixir: "1.16"
           - pair:
-              otp: 26.x
-              elixir: 1.15.x
+              otp: "26"
+              elixir: "1.15"
 
           - pair:
-              otp: 25.x
-              elixir: 1.17.x
+              otp: "25"
+              elixir: "1.17"
           - pair:
-              otp: 25.x
-              elixir: 1.16.x
+              otp: "25"
+              elixir: "1.16"
           - pair:
-              otp: 25.x
-              elixir: 1.15.x
+              otp: "25"
+              elixir: "1.15"
           - pair:
-              otp: 25.x
-              elixir: 1.14.x
+              otp: "25"
+              elixir: "1.14"
 
           - pair:
-              otp: 24.x
-              elixir: 1.16.x
+              otp: "24"
+              elixir: "1.16"
           - pair:
-              otp: 24.x
-              elixir: 1.15.x
+              otp: "24"
+              elixir: "1.15"
           - pair:
-              otp: 24.x
-              elixir: 1.14.x
+              otp: "24"
+              elixir: "1.14"
           - pair:
-              otp: 24.x
-              elixir: 1.13.x
+              otp: "24"
+              elixir: "1.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +60,7 @@ jobs:
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             deps

--- a/test/support/file_helpers.ex
+++ b/test/support/file_helpers.ex
@@ -18,7 +18,13 @@ defmodule Support.FileHelpers do
   Note: It doesn't appear this can be run with `use ExUnit.Case, async: true`
   """
   defmacro in_tmp(fun) do
-    path = Path.join([tmp_path(), "#{__CALLER__.module}", "#{elem(__CALLER__.function, 0)}"])
+    fn_name =
+      case __CALLER__.function do
+        {fn_name, _arity} -> fn_name
+        _ -> "unknown"
+      end
+
+    path = Path.join([tmp_path(), "#{__CALLER__.module}", "#{fn_name}"])
 
     quote do
       path = unquote(path)


### PR DESCRIPTION
We also use specific versions by string instead of number, see https://github.com/erlef/setup-beam?tab=readme-ov-file#specify-versions-as-strings-not-numbers